### PR TITLE
Bugfix | WTM-59 | Save userAgent on navigation entries on create

### DIFF
--- a/src/navigation/services/navigation-entry.service.ts
+++ b/src/navigation/services/navigation-entry.service.ts
@@ -44,6 +44,7 @@ export class NavigationEntryService {
         data: {
           ...createNavigationEntryInputDto,
           userId: jwtContext.user.id,
+          userAgent: jwtContext?.session?.userAgent || '',
         },
       });
     }


### PR DESCRIPTION
## Bugfix | WTM-59 | Save userAgent on navigation entries on create

### Issue:  https://github.com/webtimemachine/wtm2/issues/59 
### Ticket: https://github.com/orgs/webtimemachine/projects/2/views/2?pane=issue&itemId=53428428

### Changes: 
- We added the userAgent of the session on navigation entry creation

