### PR TITLE
Feature | WTM-88 | Add expiration date and filter navigation entries

### DIFF
--- a/src/navigation/dtos/navigation-entry.dto.ts
+++ b/src/navigation/dtos/navigation-entry.dto.ts
@@ -23,6 +23,10 @@ export class NavigationEntryDto {
   @Expose()
   navigationDate: Date;
 
+  @ApiProperty({ required: false })
+  @Expose()
+  expirationDate?: Date;
+
   @ApiProperty()
   @Expose()
   userId: number;

--- a/src/navigation/services/navigation-entry.service.spec.ts
+++ b/src/navigation/services/navigation-entry.service.spec.ts
@@ -29,7 +29,7 @@ const existingUser = {
   userPreferences: {
     id: BigInt(1),
     userId: BigInt(1),
-    enableNavigationEntryExpiration: true,
+    enableNavigationEntryExpiration: false,
     navigationEntryExpirationInDays: 120,
     createdAt: new Date(),
     updateAt: new Date(),


### PR DESCRIPTION
## Feature | WTM-88 | Add expiration date and filter navigation entries

### Issue: https://github.com/webtimemachine/wtm2/issues/88
### Ticket: https://github.com/orgs/webtimemachine/projects/2/views/2?pane=issue&itemId=56234177

### Changes:
- We implemented a new optional field on the navigation entry dto called `expirationDate`
    - This value will ve present when the user has the preference of the navigation entry expiration enabled and the expiration in days setted up
- The value of `expirationDate` will be populated on runningtime and is calculated by the `navigationDate` plus the `navigationEntryExpirationInDays`
- We are also filtering the navigation entries on the `GET /api/navigation-entry` endpoint to exclude the expired navigation entries from the response