### PR TITLE
Feature | WTM-145 | Endpoint to get a list of active sessions

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -18,6 +18,7 @@ import {
 } from '../../common/decorators';
 import { MessageResponse } from '../../common/dtos';
 import {
+  JwtAccessToken,
   JwtPartialToken,
   JwtRecoveryToken,
   JwtRefreshToken,
@@ -42,6 +43,7 @@ import {
   PartialJwtContext,
 } from '../interfaces';
 import { AuthService } from '../services';
+import { CompleteSessionDto } from '../dtos/complete-session.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -166,5 +168,19 @@ export class AuthController {
     @Body() restorePasswordDto: RestorePasswordDto,
   ): Promise<LoginResponseDto | SignUpResponseDto> {
     return this.authService.restorePassword(context, restorePasswordDto);
+  }
+
+  @ApiOkResponse({
+    status: 200,
+    type: CompleteSessionDto,
+    isArray: true,
+  })
+  @JwtAccessToken()
+  @HttpCode(200)
+  @Get('session')
+  async getActiveSessions(
+    @JwtRequestContext() context: JwtContext,
+  ): Promise<CompleteSessionDto[]> {
+    return this.authService.getActiveSessions(context);
   }
 }

--- a/src/auth/dtos/complete-session.dto.ts
+++ b/src/auth/dtos/complete-session.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Exclude } from 'class-transformer';
+
+import { UserDeviceDto } from '../../user/dtos/user-device.dto';
+
+@Exclude()
+export class CompleteSessionDto {
+  @ApiProperty()
+  @Expose()
+  id: number;
+
+  @ApiProperty()
+  @Expose()
+  userDeviceId: number;
+
+  @ApiProperty()
+  @Expose()
+  expiration: Date;
+
+  @ApiProperty()
+  @Expose()
+  createdAt: Date;
+
+  @ApiProperty({ required: false })
+  @Expose()
+  updateAt?: Date;
+
+  @ApiProperty({ type: () => UserDeviceDto })
+  @Expose()
+  userDevice: UserDeviceDto;
+}


### PR DESCRIPTION
## Feature | WTM-145 | Endpoint to get a list of active sessions

### Issue: https://github.com/webtimemachine/wtm2/issues/145
### Ticket: https://github.com/orgs/webtimemachine/projects/2/views/2?pane=issue&itemId=57085182

### Changes: 
- We implemented the endpoint GET `/api/auth/session` 
![image](https://github.com/webtimemachine/wtm2/assets/88394108/2f77d22d-d2b4-4e57-8333-365c8cace292)

- We also implemented a unit test for the `getActiveSessions` method of the authService
