### PR TITLE
Feature | WTM-149 | Logout and Session logout endpoints

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -88,6 +88,19 @@ export class AuthController {
 
   @ApiOkResponse({
     status: 200,
+    type: MessageResponse,
+  })
+  @JwtAccessToken()
+  @HttpCode(200)
+  @Post('logout')
+  async logout(
+    @JwtRequestContext() context: JwtContext,
+  ): Promise<MessageResponse> {
+    return this.authService.logout(context);
+  }
+
+  @ApiOkResponse({
+    status: 200,
     type: LoginResponseDto,
   })
   @ApiUnauthorizedMessageResponse()

--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -44,6 +44,7 @@ import {
 } from '../interfaces';
 import { AuthService } from '../services';
 import { CompleteSessionDto } from '../dtos/complete-session.dto';
+import { LogoutSessionInputDto } from '../dtos/logout-session.input.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -195,5 +196,18 @@ export class AuthController {
     @JwtRequestContext() context: JwtContext,
   ): Promise<CompleteSessionDto[]> {
     return this.authService.getActiveSessions(context);
+  }
+
+  @ApiOkResponse({
+    status: 200,
+    type: MessageResponse,
+  })
+  @JwtAccessToken()
+  @HttpCode(200)
+  @Post('session/logout')
+  async logoutSession(
+    @Body() logoutSessionInputDto: LogoutSessionInputDto,
+  ): Promise<MessageResponse> {
+    return this.authService.logoutSession(logoutSessionInputDto);
   }
 }

--- a/src/auth/dtos/logout-session.input.dto.ts
+++ b/src/auth/dtos/logout-session.input.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class LogoutSessionInputDto {
+  @ApiProperty()
+  @IsNumber()
+  sessionId: number;
+}

--- a/src/auth/dtos/logout-session.input.dto.ts
+++ b/src/auth/dtos/logout-session.input.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber } from 'class-validator';
 
 export class LogoutSessionInputDto {
-  @ApiProperty()
-  @IsNumber()
-  sessionId: number;
+  @ApiProperty({ isArray: true })
+  @IsNumber({}, { each: true })
+  sessionIds: number[];
 }

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -318,6 +318,22 @@ export class AuthService {
     });
   }
 
+  async logout(jwtContext: JwtContext): Promise<MessageResponse> {
+    const deletedSession = await this.prismaService.session.delete({
+      where: {
+        id: jwtContext.session.id,
+      },
+    });
+
+    if (deletedSession) {
+      return plainToInstance(MessageResponse, {
+        message: 'Logout successfully',
+      });
+    } else {
+      throw new NotFoundException();
+    }
+  }
+
   async refreshToken(context: JwtRefreshContext): Promise<RefreshResponseDto> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { iat, exp, ...rest } = context.payload;

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -51,6 +51,7 @@ import { MessageResponse } from '../../common/dtos';
 import { generateNumericCode } from '../../common/helpers';
 import { appEnv } from '../../config';
 import { CompleteSessionDto } from '../dtos/complete-session.dto';
+import { LogoutSessionInputDto } from '../dtos/logout-session.input.dto';
 
 @Injectable()
 export class AuthService {
@@ -632,5 +633,25 @@ export class AuthService {
         include: completeSessionInclude,
       });
     return AuthService.completeSessionsToDtos(jwtContext, completeSessions);
+  }
+
+  async logoutSession(
+    logoutSessionInputDto: LogoutSessionInputDto,
+  ): Promise<MessageResponse> {
+    const { sessionId } = logoutSessionInputDto;
+
+    const deletedSession = await this.prismaService.session.delete({
+      where: {
+        id: sessionId,
+      },
+    });
+
+    if (deletedSession) {
+      return plainToInstance(MessageResponse, {
+        message: 'Logout successfully',
+      });
+    } else {
+      throw new NotFoundException();
+    }
   }
 }


### PR DESCRIPTION
## Feature | WTM-149 | Logout and Session logout endpoints

### Issue: https://github.com/webtimemachine/wtm2/issues/149
### Ticket: https://github.com/orgs/webtimemachine/projects/2/views/2?pane=issue&itemId=57085202

### Changes:
- We implemented a logout endpoint on POST `/api/auth/logout` and an endpoint to logout a sessions by id on POST `/api/auth/session`

![image](https://github.com/webtimemachine/wtm2/assets/88394108/a01db357-555a-4f65-81ed-778891582fdd)
![image](https://github.com/webtimemachine/wtm2/assets/88394108/74647409-5358-44ef-993a-ce93c767670b)
