### PR TITLE
Feature | WTM-192 | Refresh token integration

### DIFF
--- a/app/src/background/api.client.ts
+++ b/app/src/background/api.client.ts
@@ -1,4 +1,5 @@
 import { LoginData, LoginResponse } from './interfaces/login.interface';
+
 class ApiClient {
   async fetch(endpoint: string, init: RequestInit = {}): Promise<Response> {
     const { serverUrl, accessToken } = await chrome.storage.local.get([
@@ -6,24 +7,43 @@ class ApiClient {
       'accessToken',
     ]);
 
-    if (accessToken) {
-      init = {
-        ...init,
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-          ...init?.headers,
-        },
-      };
-    }
+    try {
+      if (accessToken) {
+        init = {
+          ...init,
+          headers: {
+            'Content-Type': 'application/json',
+            ...init?.headers,
+            Authorization: `Bearer ${accessToken}`,
+          },
+        };
+      }
+      const res = await fetch(new URL(endpoint, serverUrl), init);
 
-    return fetch(new URL(endpoint, serverUrl), init);
+      if (res.status === 401) {
+        const jsonRes = await res.json();
+        console.error('ApiClient', { endpoint, response: jsonRes });
+        throw new Error('Unauthorized');
+      }
+
+      return res;
+    } catch (error: any) {
+      if (error?.message === 'Unauthorized') {
+        try {
+          await this.refresh();
+          console.log('ApiClient Retrying request after refresh', { endpoint });
+          return this.fetch(endpoint, init);
+        } catch (error) {
+          throw error;
+        }
+      } else {
+        throw error;
+      }
+    }
   }
 
   async login(data: LoginData): Promise<LoginResponse> {
     const { serverUrl } = await chrome.storage.local.get(['serverUrl']);
-    console.log('login', data);
-
     try {
       const res = await fetch(new URL('/api/auth/login', serverUrl), {
         method: 'POST',
@@ -48,6 +68,37 @@ class ApiClient {
       return loginResponse;
     } catch (error) {
       console.error('ApiClient login', error);
+      throw error;
+    }
+  }
+
+  async refresh(): Promise<void> {
+    console.log('ApiClient Refreshing...');
+    const { serverUrl, refreshToken } = await chrome.storage.local.get([
+      'serverUrl',
+      'refreshToken',
+    ]);
+
+    try {
+      const res = await fetch(new URL('/api/auth/refresh', serverUrl), {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (res.status !== 200) {
+        throw new Error('Unauthorized');
+      }
+
+      const data = await res.json();
+      await chrome.storage.local.set({
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
+      });
+    } catch (error) {
+      console.error('ApiClient Refresh Error', error);
       throw error;
     }
   }

--- a/app/src/components/server-url-editable.component.tsx
+++ b/app/src/components/server-url-editable.component.tsx
@@ -11,7 +11,8 @@ import {
 } from '@chakra-ui/react';
 import { CheckIcon, CloseIcon, EditIcon } from '@chakra-ui/icons';
 
-import { useServerUrl } from '../store';
+import { useServerUrl } from '../hooks';
+
 import clsx from 'clsx';
 
 const EditableControls = () => {

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useSayHello } from './use-say-hello.hook';
 export { useGetVersion } from './use-get-version.hook';
 export { useLogin } from './use-login.hook';
+export { useIsLoggedIn } from './use-logged-in.hook';
+export { useServerUrl } from './use-server-url.hook';

--- a/app/src/hooks/use-logged-in.hook.ts
+++ b/app/src/hooks/use-logged-in.hook.ts
@@ -1,0 +1,13 @@
+export const useIsLoggedIn = () => {
+  const isLoggedIn = async (): Promise<boolean> => {
+    const tokens = await chrome.storage.local.get([
+      'accessToken',
+      'refreshToken',
+    ]);
+
+    const { accessToken, refreshToken } = tokens;
+    return (accessToken ?? false) && (refreshToken ?? false);
+  };
+
+  return { isLoggedIn };
+};

--- a/app/src/hooks/use-logout.hook.ts
+++ b/app/src/hooks/use-logout.hook.ts
@@ -1,0 +1,15 @@
+import { useNavigationStore } from '../store';
+
+export const useLogout = () => {
+  const { navigateTo } = useNavigationStore();
+
+  const logout = async () => {
+    await chrome.storage.local.set({
+      accessToken: '',
+      refreshToken: '',
+    });
+    navigateTo('login');
+  };
+
+  return { logout };
+};

--- a/app/src/hooks/use-server-url.hook.ts
+++ b/app/src/hooks/use-server-url.hook.ts
@@ -1,0 +1,7 @@
+import { useAuthStore } from '../store';
+
+export const useServerUrl = () => {
+  const serverUrl = useAuthStore((state) => state.serverUrl);
+  const setServerUrl = useAuthStore((state) => state.setServerUrl);
+  return { serverUrl, setServerUrl };
+};

--- a/app/src/store/auth.store.ts
+++ b/app/src/store/auth.store.ts
@@ -2,7 +2,6 @@ import { useStore } from 'zustand';
 import { createStore } from 'zustand/vanilla';
 import { persist } from 'zustand/middleware';
 import { getRandomToken } from '../utils';
-import { useNavigationStore } from '.';
 
 interface AuthStore {
   deviceKey: string;
@@ -33,26 +32,6 @@ export const authStore = createStore<AuthStore>()(
 
 export const useAuthStore = <T>(selector?: (state: AuthStore) => T) =>
   useStore(authStore, selector!);
-
-export const useLogout = () => {
-  const { navigateTo } = useNavigationStore();
-
-  const logout = async () => {
-    await chrome.storage.local.set({
-      accessToken: '',
-      refreshToken: '',
-    });
-    navigateTo('login');
-  };
-
-  return { logout };
-};
-
-export const useServerUrl = () => {
-  const serverUrl = useAuthStore((state) => state.serverUrl);
-  const setServerUrl = useAuthStore((state) => state.setServerUrl);
-  return { serverUrl, setServerUrl };
-};
 
 const initStorage = async () => {
   const { serverUrl } = await chrome.storage.local.get(['serverUrl']);

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -1,2 +1,2 @@
 export { useNavigationStore } from './navigation.store';
-export { authStore, useAuthStore, useLogout, useServerUrl } from './auth.store';
+export { authStore, useAuthStore } from './auth.store';

--- a/backend/src/auth/services/auth.service.ts
+++ b/backend/src/auth/services/auth.service.ts
@@ -97,7 +97,7 @@ export class AuthService {
   private buildRefreshToken(payload: JWTPayload): string {
     return this.jwtService.sign(payload, {
       secret: appEnv.JWT_REFRESH_SECRET,
-      expiresIn: appEnv.JWT_REFRESH_EXPIRATION,
+      ...(payload?.exp ? {} : { expiresIn: appEnv.JWT_REFRESH_EXPIRATION }),
     });
   }
 
@@ -339,7 +339,7 @@ export class AuthService {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { iat, exp, ...rest } = context.payload;
     const accessToken = this.buildAccessToken(rest);
-    const refreshToken = this.buildRefreshToken(rest);
+    const refreshToken = this.buildRefreshToken({ ...rest, exp });
 
     const { exp: expiration } = this.jwtService.decode(refreshToken) as {
       exp: number;


### PR DESCRIPTION
## Feature | WTM-192 | Refresh token integration 

### Issue: https://github.com/webtimemachine/wtm2/issues/192
### Ticket: https://github.com/orgs/webtimemachine/projects/2/views/1?pane=issue&itemId=60577568

### Changes:
- We implemented the refresh integration on the apiClient by using the `/api/auth/refresh` endpoint and retry the requests when they fail with 401