### PR TITLE
Bugfix | WTM-341 | Extend Typescript config for Jest

### DIFF
--- a/webpage/jest.config.ts
+++ b/webpage/jest.config.ts
@@ -3,7 +3,7 @@ const config = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
     // process `*.tsx` files with `ts-jest`
   },
   moduleNameMapper: {

--- a/webpage/package.json
+++ b/webpage/package.json
@@ -8,8 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --passWithNoTests --detectOpenHandles",
-    "test:cov": "jest --passWithNoTests --detectOpenHandles --coverage"
+    "test": "tsc --project tsconfig.test.json && jest --passWithNoTests --detectOpenHandles",
+    "test:cov": "tsc --project tsconfig.test.json && jest --passWithNoTests --detectOpenHandles --coverage"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",

--- a/webpage/tsconfig.json
+++ b/webpage/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "allowImportingTsExtensions": true,
     "incremental": true,
     "plugins": [
@@ -19,9 +23,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/webpage/tsconfig.test.json
+++ b/webpage/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "**/*.test.tsx"]
+}


### PR DESCRIPTION
### Issue: [#341](https://github.com/webtimemachine/wtm2/issues/341)

### 📑 Changes:

- We update the Typescript config to solve warning when we run the test

### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
