### PR TITLE
Feature | WTM-477 | Throw backend errors to discord channel

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -43,6 +43,7 @@
     "@sentry/node": "^8.12.0",
     "@sentry/profiling-node": "^8.12.0",
     "@sentry/tracing": "^7.114.0",
+    "axios": "^1.7.7",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",

--- a/apps/backend/src/app.controller.ts
+++ b/apps/backend/src/app.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get, Logger } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { AppService } from './app.service';
 import { GetVersionResponse } from './dtos';
 
+import { CustomLogger } from './common/helpers/custom-logger';
+
 @ApiTags('Root')
 @Controller()
 export class AppController {
-  private readonly logger: Logger = new Logger(AppController.name);
+  private readonly logger: CustomLogger = new CustomLogger(AppController.name);
 
   constructor(private readonly appService: AppService) {}
 

--- a/apps/backend/src/app.service.ts
+++ b/apps/backend/src/app.service.ts
@@ -1,12 +1,13 @@
-import { Logger } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 
 import { PrismaService } from './common/services';
 import { GetVersionResponse } from './dtos';
 import { getVersion } from './getVersion';
 
+import { CustomLogger } from './common/helpers/custom-logger';
+
 export class AppService {
-  private readonly logger = new Logger(AppService.name);
+  private readonly logger = new CustomLogger(AppService.name);
 
   constructor(private readonly prismaService: PrismaService) {}
 

--- a/apps/backend/src/auth/controllers/auth.controller.spec.ts
+++ b/apps/backend/src/auth/controllers/auth.controller.spec.ts
@@ -151,7 +151,6 @@ describe('AuthController', () => {
           deletedAt: null,
           displayname: '',
           passChangedAt: new Date(),
-          profilePicture: '',
         },
       };
 
@@ -181,7 +180,6 @@ describe('AuthController', () => {
             displayname: '',
             profilePicture: 'profilePicture',
             passChangedAt: expect.any(Date),
-            profilePicture: '',
           },
         }),
         expect.objectContaining({

--- a/apps/backend/src/auth/controllers/auth.controller.ts
+++ b/apps/backend/src/auth/controllers/auth.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   Get,
   HttpCode,
-  Logger,
   Post,
   Req,
   UseGuards,
@@ -46,10 +45,12 @@ import { AuthService } from '../services';
 import { CompleteSessionDto } from '../dtos/complete-session.dto';
 import { LogoutSessionInputDto } from '../dtos/logout-session.input.dto';
 
+import { CustomLogger } from '../../common/helpers/custom-logger';
+
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  private readonly logger = new Logger(AuthController.name);
+  private readonly logger = new CustomLogger(AuthController.name);
   constructor(private readonly authService: AuthService) {}
 
   @ApiInternalServerErrorMessageResponse()

--- a/apps/backend/src/auth/guards/user-type.guard.ts
+++ b/apps/backend/src/auth/guards/user-type.guard.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   CanActivate,
   ExecutionContext,
-  Logger,
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -10,9 +9,11 @@ import { Observable } from 'rxjs';
 import { Reflector } from '@nestjs/core';
 import { JwtContext } from '../interfaces';
 
+import { CustomLogger } from '../../common/helpers/custom-logger';
+
 @Injectable()
 export class UserTypesGuard implements CanActivate {
-  private readonly logger = new Logger(UserTypesGuard.name);
+  private readonly logger = new CustomLogger(UserTypesGuard.name);
 
   constructor(private reflector: Reflector) {}
 

--- a/apps/backend/src/auth/services/auth.service.spec.ts
+++ b/apps/backend/src/auth/services/auth.service.spec.ts
@@ -52,7 +52,6 @@ describe('AuthService', () => {
       createdAt: new Date(),
       updateAt: new Date(),
     },
-    profilePicture: '',
   };
 
   const nonVerifiedUser: CompleteUser = {
@@ -80,7 +79,6 @@ describe('AuthService', () => {
       createdAt: new Date(),
       updateAt: new Date(),
     },
-    profilePicture: '',
   };
 
   const signUpDtoRequest = {
@@ -260,7 +258,6 @@ describe('AuthService', () => {
             createdAt: new Date('2024-04-08T16:58:29.000Z'),
             updateAt: new Date('2024-04-08T16:58:29.000Z'),
           },
-          profilePicture: '',
         },
         session: {
           id: BigInt(1),

--- a/apps/backend/src/auth/services/auth.service.ts
+++ b/apps/backend/src/auth/services/auth.service.ts
@@ -53,9 +53,11 @@ import { appEnv } from '../../config';
 import { CompleteSessionDto } from '../dtos/complete-session.dto';
 import { LogoutSessionInputDto } from '../dtos/logout-session.input.dto';
 
+import { CustomLogger } from '../../common/helpers/custom-logger';
+
 @Injectable()
 export class AuthService {
-  private readonly logger = new Logger(AuthService.name);
+  private readonly logger = new CustomLogger(AuthService.name);
 
   constructor(
     private readonly prismaService: PrismaService,

--- a/apps/backend/src/auth/strategies/jwt-partial.strategy.ts
+++ b/apps/backend/src/auth/strategies/jwt-partial.strategy.ts
@@ -1,9 +1,11 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JWTPayload, PartialJwtContext } from '../interfaces';
 import { PrismaService } from '../../common/services';
 import { appEnv } from '../../config';
+
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 const jwtFromRequest = ExtractJwt.fromExtractors([
   ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -14,7 +16,7 @@ export class JwtVerificationTokenStrategy extends PassportStrategy(
   Strategy,
   'jwt-partial-token',
 ) {
-  private readonly logger = new Logger(JwtVerificationTokenStrategy.name);
+  private readonly logger = new CustomLogger(JwtVerificationTokenStrategy.name);
 
   constructor(private readonly prismaService: PrismaService) {
     super({

--- a/apps/backend/src/auth/strategies/jwt-recovery-token.strategy.ts
+++ b/apps/backend/src/auth/strategies/jwt-recovery-token.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PrismaService } from '../../common/services';
@@ -6,6 +6,8 @@ import { appEnv } from '../../config';
 import { completeUserInclude } from '../../user/types';
 import { JWTPayload } from '../interfaces';
 import { RecoveryJwtContext } from '../interfaces/jwt-context.interface';
+
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 const jwtFromRequest = ExtractJwt.fromExtractors([
   ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -16,7 +18,7 @@ export class JwtRecoveryTokenStrategy extends PassportStrategy(
   Strategy,
   'jwt-recovery-token',
 ) {
-  private readonly logger = new Logger(JwtRecoveryTokenStrategy.name);
+  private readonly logger = new CustomLogger(JwtRecoveryTokenStrategy.name);
 
   constructor(private readonly prismaService: PrismaService) {
     super({

--- a/apps/backend/src/common/helpers/custom-logger.ts
+++ b/apps/backend/src/common/helpers/custom-logger.ts
@@ -1,0 +1,96 @@
+import { ConsoleLogger } from '@nestjs/common';
+import axios from 'axios';
+
+import { appEnv } from '../../config';
+
+export class CustomLogger extends ConsoleLogger {
+  private discordLogWebhookUrl?: string;
+
+  private discordLog: boolean;
+  private discordError: boolean;
+  private discordWarn: boolean;
+  private discordDebug: boolean;
+  private discordVerbose: boolean;
+
+  constructor(context: string) {
+    super(context);
+    this.discordLogWebhookUrl = appEnv.DISCORD_LOG_WEBHOOK_URL;
+
+    this.discordLog = appEnv.DISCORD_LOG || false;
+    this.discordError = appEnv.DISCORD_ERROR || false;
+    this.discordWarn = appEnv.DISCORD_WARN || false;
+    this.discordDebug = appEnv.DISCORD_DEBUG || false;
+    this.discordVerbose = appEnv.DISCORD_VERBOSE || false;
+  }
+
+  log(message: string) {
+    if (this.discordLog) this.sendToDiscord('LOG', message);
+    super.log(message);
+  }
+
+  error(message: string, trace?: string) {
+    if (this.discordError) this.sendToDiscord('ERROR', message, trace);
+    super.error(message, trace);
+  }
+
+  warn(message: string) {
+    if (this.discordWarn) this.sendToDiscord('WARN', message);
+    super.warn(message);
+  }
+
+  debug(message: string) {
+    if (this.discordDebug) this.sendToDiscord('DEBUG', message);
+    super.debug(message);
+  }
+
+  verbose(message: string) {
+    if (this.discordVerbose) this.sendToDiscord('VERBOSE', message);
+    super.verbose(message);
+  }
+
+  private async sendToDiscord(
+    level: string,
+    message: string,
+    details?: string,
+  ): Promise<void> {
+    const embed = {
+      embeds: [
+        {
+          title: `${level} Log`,
+          description: message,
+          color: this.getLogColor(level),
+          fields: details
+            ? [{ name: 'Details', value: `\`\`\`${details}\`\`\`` }]
+            : [],
+          footer: {
+            text: `Logged by: ${this.context}`,
+          },
+          timestamp: new Date(),
+        },
+      ],
+    };
+
+    try {
+      if (this.discordLogWebhookUrl) {
+        await axios.post(this.discordLogWebhookUrl, embed);
+      }
+    } catch (error) {
+      super.error(`Failed to send log to Discord: ${error.message}`);
+    }
+  }
+
+  private getLogColor(level: string): number {
+    switch (level) {
+      case 'ERROR':
+        return 0xff0000; // Red
+      case 'WARN':
+        return 0xffa500; // Orange
+      case 'DEBUG':
+        return 0xbf70d2; // Purple
+      case 'VERBOSE':
+        return 0x00ced1; // Dark Turquoise
+      default:
+        return 0x3498db; // Blue
+    }
+  }
+}

--- a/apps/backend/src/common/services/email.service.ts
+++ b/apps/backend/src/common/services/email.service.ts
@@ -1,9 +1,10 @@
 import { MailerService } from '@nestjs-modules/mailer';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 @Injectable()
 export class EmailService {
-  private logger = new Logger('EmailService');
+  private logger = new CustomLogger('EmailService');
 
   constructor(private readonly mailerService: MailerService) {}
 

--- a/apps/backend/src/common/services/prisma.service.ts
+++ b/apps/backend/src/common/services/prisma.service.ts
@@ -1,14 +1,11 @@
-import {
-  INestApplication,
-  Injectable,
-  Logger,
-  OnModuleInit,
-} from '@nestjs/common';
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
+
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
-  private logger = new Logger('PrismaService');
+  private logger = new CustomLogger('PrismaService');
 
   constructor() {
     super();

--- a/apps/backend/src/config/env.config.ts
+++ b/apps/backend/src/config/env.config.ts
@@ -36,6 +36,12 @@ const envSchemas = {
   SENTRY_AUTH_TOKEN: z.string().optional(),
   AVOID_DOMAIN_LIST: z.string().optional(),
   CRON_SECRET: z.string().optional(),
+  DISCORD_LOG_WEBHOOK_URL: z.string().optional(),
+  DISCORD_LOG: z.boolean().optional(),
+  DISCORD_ERROR: z.boolean().optional(),
+  DISCORD_WARN: z.boolean().optional(),
+  DISCORD_DEBUG: z.boolean().optional(),
+  DISCORD_VERBOSE: z.boolean().optional(),
 };
 
 const envSchema = z.object({

--- a/apps/backend/src/encoder/services/index.ts
+++ b/apps/backend/src/encoder/services/index.ts
@@ -1,13 +1,14 @@
 import { OpenAI, OpenAIEmbeddings } from '@langchain/openai';
 import { WeaviateLibArgs, WeaviateStore } from '@langchain/weaviate';
 import { Document } from '@langchain/core/documents';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
 import weaviate from 'weaviate-ts-client';
 import { PrismaService } from '../../common/services';
 import { appEnv } from '../../config';
 import { caption } from '../utils';
 import { SemanticSearchResult } from '../types';
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 const textSplitter = new RecursiveCharacterTextSplitter({
   chunkSize: 1000,
@@ -25,7 +26,7 @@ const client = weaviate.client({
 
 @Injectable()
 export class IndexerService {
-  private readonly logger = new Logger(IndexerService.name);
+  private readonly logger = new CustomLogger(IndexerService.name);
   private readonly multitenantCollection = 'MultiTenancyCollection';
 
   constructor(private readonly prismaService: PrismaService) {}

--- a/apps/backend/src/filter/services/index.ts
+++ b/apps/backend/src/filter/services/index.ts
@@ -4,10 +4,10 @@ import {
 } from '@langchain/core/output_parsers';
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
-import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { PrismaService } from '../../common/services';
 import { appEnv } from '../../config';
-
+import { CustomLogger } from '../../common/helpers/custom-logger';
 export class FlagParser extends BaseOutputParser<boolean> {
   lc_namespace = ['langchain', 'output_parsers'];
   async parse(text: string): Promise<boolean> {
@@ -35,7 +35,9 @@ const filterPrompt = ChatPromptTemplate.fromMessages([
 
 @Injectable()
 export class ExplicitFilterService {
-  private readonly logger: Logger = new Logger(ExplicitFilterService.name);
+  private readonly logger: CustomLogger = new CustomLogger(
+    ExplicitFilterService.name,
+  );
 
   constructor(private readonly prismaService: PrismaService) {}
 

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory, HttpAdapterHost } from '@nestjs/core';
 
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -13,6 +13,7 @@ import { options } from './swagger-options';
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { SentryFilter } from './sentry.filter';
+import { CustomLogger } from './common/helpers/custom-logger';
 
 const initSentry = () => {
   Sentry.init({
@@ -24,7 +25,7 @@ const initSentry = () => {
 };
 
 async function bootstrap() {
-  const logger = new Logger('bootstrap');
+  const logger = new CustomLogger('bootstrap');
 
   const app = await NestFactory.create(AppModule);
 

--- a/apps/backend/src/navigation/controllers/navigation-entry.controller.ts
+++ b/apps/backend/src/navigation/controllers/navigation-entry.controller.ts
@@ -4,7 +4,6 @@ import {
   Delete,
   Get,
   HttpCode,
-  Logger,
   Param,
   ParseIntPipe,
   Post,
@@ -35,11 +34,12 @@ import {
   ApiPaginationResponse,
 } from '../../common/decorators';
 import { MessageResponse, PaginationResponse } from '../../common/dtos';
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 @ApiTags('Navigation Entry')
 @Controller('navigation-entry')
 export class NavigationEntryController {
-  private readonly logger = new Logger(NavigationEntryController.name);
+  private readonly logger = new CustomLogger(NavigationEntryController.name);
 
   constructor(private readonly navigationService: NavigationEntryService) {}
 

--- a/apps/backend/src/navigation/services/navigation-entry.service.spec.ts
+++ b/apps/backend/src/navigation/services/navigation-entry.service.spec.ts
@@ -59,7 +59,6 @@ const existingUser: CompleteUser = {
     createdAt: new Date(),
     updateAt: new Date(),
   },
-  profilePicture: '',
 };
 
 const mockedSession = {

--- a/apps/backend/src/navigation/services/navigation-entry.service.ts
+++ b/apps/backend/src/navigation/services/navigation-entry.service.ts
@@ -1,7 +1,6 @@
 import {
   ForbiddenException,
   Injectable,
-  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { NavigationEntry, Prisma } from '@prisma/client';
@@ -31,10 +30,11 @@ import { QueryService } from '../../query/services';
 import { ExplicitFilterService } from '../../filter/services';
 import { appEnv } from '../../config';
 import { subDays } from 'date-fns';
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 @Injectable()
 export class NavigationEntryService {
-  private readonly logger = new Logger(NavigationEntryService.name);
+  private readonly logger = new CustomLogger(NavigationEntryService.name);
 
   constructor(
     private readonly prismaService: PrismaService,

--- a/apps/backend/src/query/services/index.spec.ts
+++ b/apps/backend/src/query/services/index.spec.ts
@@ -52,7 +52,6 @@ const existingUser: CompleteUser = {
     createdAt: new Date(),
     updateAt: new Date(),
   },
-  profilePicture: '',
 };
 
 const mockedSession = {

--- a/apps/backend/src/user/controllers/user.controller.ts
+++ b/apps/backend/src/user/controllers/user.controller.ts
@@ -4,7 +4,6 @@ import {
   Delete,
   Get,
   HttpCode,
-  Logger,
   Param,
   ParseIntPipe,
   Put,
@@ -24,11 +23,12 @@ import {
   UserDeviceDto,
 } from '../dtos';
 import { UserService } from '../services';
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 @ApiTags('User')
 @Controller('user')
 export class UserController {
-  private readonly logger = new Logger(UserController.name);
+  private readonly logger = new CustomLogger(UserController.name);
   constructor(private readonly userService: UserService) {}
 
   @ApiOkResponse({

--- a/apps/backend/src/user/services/user.service.spec.ts
+++ b/apps/backend/src/user/services/user.service.spec.ts
@@ -44,7 +44,6 @@ const existingUser: CompleteUser = {
     createdAt: new Date(),
     updateAt: new Date(),
   },
-  profilePicture: '',
 };
 
 const mockedSession = {

--- a/apps/backend/src/user/services/user.service.ts
+++ b/apps/backend/src/user/services/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { User } from '@prisma/client';
 
 import { JwtContext } from '../../auth/interfaces';
@@ -22,10 +22,11 @@ import { CompleteUserDevice, completeUserDeviceInclude } from '../types';
 
 import { UAParser } from 'ua-parser-js';
 import { AuthService } from '../../auth/services';
+import { CustomLogger } from '../../common/helpers/custom-logger';
 
 @Injectable()
 export class UserService {
-  private readonly logger = new Logger(UserService.name);
+  private readonly logger = new CustomLogger(UserService.name);
 
   constructor(
     private readonly prismaService: PrismaService,

--- a/guides/setup-backend-environment-variables.md
+++ b/guides/setup-backend-environment-variables.md
@@ -55,5 +55,26 @@ Copy the `sample.env` to `.env` and `sample.db.env` to `db.env` on the backend f
 17. **AVOID_DOMAIN_LIST**:
     - Example: **`AVOID_DOMAIN_LIST='localhost, www.webtm.io, webtm.vercel.app'`**
     - Usage: Specifies the domains list to avoid to track.
+18. **CRON_SECRET**:
+    - Example: **`CRON_SECRET=4b2cfcf5-cf24-4fa7-b5d0-80920e3ff9ea`**
+    - Usage: Used to secure recurring endpoints executed by scheduled tasks (cron jobs). The `CRON_SECRET` value is extracted from the bearer token in the backend and validated to authorize access to these endpoints. This environment variable is set in Vercel and sent in cron requests to securely authenticate the process.
+19. **DISCORD_LOG_WEBHOOK_URL**:
+    - Example: **`DISCORD_LOG_WEBHOOK_URL=https://discord.com/api/webhooks/your_webhook_url`**
+    - Usage: The URL for the Discord webhook where logs will be sent. This should be the URL of the webhook in the Discord channel where you want to receive log messages.
+20. **DISCORD_LOG**:
+    - Example: **`DISCORD_LOG=true`**
+    - Usage: Enables or disables sending standard log messages to Discord. Set to `true` to activate or `false` to deactivate.
+21. **DISCORD_ERROR**:
+    - Example: **`DISCORD_ERROR=true`**
+    - Usage: Enables or disables sending error messages to Discord. Set to `true` to send error logs to the specified Discord channel.
+22. **DISCORD_WARN**:
+    - Example: **`DISCORD_WARN=true`**
+    - Usage: Enables or disables sending warning messages to Discord. Set to `true` to send warning logs to the specified Discord channel.
+23. **DISCORD_DEBUG**:
+    - Example: **`DISCORD_DEBUG=true`**
+    - Usage: Enables or disables sending debug messages to Discord. Set to `true` to activate debug log messages in the Discord channel.
+24. **DISCORD_VERBOSE**:
+    - Example: **`DISCORD_VERBOSE=true`**
+    - Usage: Enables or disables sending verbose messages to Discord. Set to `true` to send verbose logs to the Discord channel.
 
 You will also need to set this env variables as secrets on your GitHub repository for the db migrations GitHub action to work properly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@sentry/node": "^8.12.0",
         "@sentry/profiling-node": "^8.12.0",
         "@sentry/tracing": "^7.114.0",
+        "axios": "^1.7.7",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
@@ -11623,6 +11624,16 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {


### PR DESCRIPTION
### Issue: #477

### 📑 Changes:

- We implemented a custom logger that sends logs, errors, warnings, and verbose logs to discord according to env vars configurations
    -> The integration with Discord was made using axios as the rest client and oob discord webhooks
- We integrated this custom log across all controllers and services
 
![image](https://github.com/user-attachments/assets/f75f218e-6db4-430f-82aa-821865d631ac)


### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
