### PR TITLE
Bugfix | WTM-542 | Fix ZIP process on Chrome Release files

### DIFF
--- a/.github/workflows/release-chrome-store.yml
+++ b/.github/workflows/release-chrome-store.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create ZIP file for Chrome
         run: |
-          zip -r chrome-extension.zip -j ./build/app_chrome/*
+          zip -r chrome-extension.zip ./build/app_chrome
 
       - name: Upload & release
         uses: mnao305/chrome-extension-upload@v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create ZIP files for Chrome and Firefox
         run: |
-          zip -r chrome-extension.zip -j ./build/app_chrome/*
+          zip -r chrome-extension.zip ./build/app_chrome
           zip -r firefox-extension.zip -j ./build/app_firefox/*
 
       - name: Update xcode project file


### PR DESCRIPTION
### Issue: #542

### 📑 Changes:

- We updated the zip command on the YML files for the Chrome release.

### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
