### PR TITLE
Feature | WTM-554 | Update firefox manifest to add automatic android support on addon publication

### DIFF
--- a/apps/extension/manifest-firefox.ts
+++ b/apps/extension/manifest-firefox.ts
@@ -10,6 +10,9 @@ export const manifestFirefox: ManifestV3Export = {
     gecko: {
       id: '{5790cffd-a2b7-4cb6-ad05-c5b955ddee3e}',
     },
+    gecko_android: {
+      id: '{5790cffd-a2b7-4cb6-ad05-c5b955ddee3e}',
+    },
   },
   permissions: ['tabs', 'activeTab', 'storage', 'scripting'],
   action: {


### PR DESCRIPTION
### Issue: #554

### 📑 Changes:

- We added the `gecko_android` settings on the firefox manifest to auto publish the addon with android support enabled

### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
