### PR TITLE
Bugfix | WTM-556 | Swagger version number is not showing the correct backend number on the Vercel instance

### DIFF
--- a/apps/backend/src/getVersion.ts
+++ b/apps/backend/src/getVersion.ts
@@ -1,26 +1,3 @@
-// eslint-disable-next-line
-const fs = require('fs');
-
-const readJsonFile = async (filename) => {
-  try {
-    const data = fs.readFileSync(filename, 'utf8');
-    return JSON.parse(data);
-  } catch (error) {
-    throw error;
-  }
-};
-
-export const getVersion = async () => {
-  let packageJson: any;
-
-  const paths = ['backend/package.json', './package.json', '../package.json'];
-
-  for (const path of paths) {
-    try {
-      packageJson = await readJsonFile(path);
-      break;
-    } catch (error) {}
-  }
-
-  return packageJson?.version || '0.0.1';
+export const getVersion = () => {
+  return '1.6.6';
 };

--- a/update-version.sh
+++ b/update-version.sh
@@ -38,8 +38,13 @@ echo "Updated apps/extension/manifest-firefox.ts -> $NEW_VERSION"
 sed -i '' "s/version: '[0-9]*\.[0-9]*\.[0-9]*'/version: '$NEW_VERSION'/" apps/webpage/src/manifest-web.ts
 echo "Updated apps/webpage/src/manifest-web.ts -> $NEW_VERSION"
 
+# Update version in apps/backend/src/getVersion.ts
+sed -i '' "s/return '[0-9]*\.[0-9]*\.[0-9]*'/return '$NEW_VERSION'/" apps/backend/src/getVersion.ts
+echo "Updated apps/backend/src/getVersion.ts -> $NEW_VERSION"
+
 # Update marketing version in project.pbxproj
 sed -i '' "s/MARKETING_VERSION = [0-9]*\.[0-9]*\.[0-9]*/MARKETING_VERSION = $NEW_VERSION/" native/app_ios/wtm/wtm.xcodeproj/project.pbxproj
 echo "Updated native/app_ios/wtm/wtm.xcodeproj/project.pbxproj -> $NEW_VERSION"
+
 
 echo "Version updated to $NEW_VERSION in all files."


### PR DESCRIPTION
### Issue: #556

### 📑 Changes:
- Update getVersion bed function and update script

### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
