### PR TITLE
BUGFIX | WTM-578 | Fix bug when delete too many records on weaviate

### DIFF
--- a/apps/backend/src/encoder/services/index.ts
+++ b/apps/backend/src/encoder/services/index.ts
@@ -153,6 +153,7 @@ export class IndexerService {
         new OpenAIEmbeddings({ openAIApiKey: appEnv.OPENAI_ACCESS_TOKEN }),
         await this.vectorStoreArgs(userId),
       );
+
       // remove the chunks/documents related to the given URL
       store.delete({
         filter: {
@@ -164,5 +165,22 @@ export class IndexerService {
         },
       });
     }
+  }
+
+  async bulkDelete(urls: string[], userId: bigint) {
+    const store = await WeaviateStore.fromExistingIndex(
+      new OpenAIEmbeddings({ openAIApiKey: appEnv.OPENAI_ACCESS_TOKEN }),
+      await this.vectorStoreArgs(userId),
+    );
+
+    store.delete({
+      filter: {
+        where: {
+          operator: 'ContainsAll',
+          path: ['source'],
+          valueTextArray: urls,
+        },
+      },
+    });
   }
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

### Fixes #578 

### 📑 Changes:

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes by using the markdown list syntax

  - We implemented ...
  - ...

-->

- Implement bulk delete on indexer service
- Refactor `deleteExpiredNavigationEntries` to perform bulk delete actions instead of promise.all

### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
