### PR TITLE
BUGFIX | WTM 585 | Bug close accordion after pagination was used

### DIFF
--- a/apps/extension/src/screens/navigation-entries.screen.tsx
+++ b/apps/extension/src/screens/navigation-entries.screen.tsx
@@ -96,9 +96,11 @@ const RelevantSegment = ({
   };
   return (
     <div>
-      <Text textAlign={'center'} py={5} fontSize={'large'}>
-        Relevant tags found
-      </Text>
+      {tags && tags.length > 0 && (
+        <Text textAlign={'center'} py={5} fontSize={'large'}>
+          Relevant tags found
+        </Text>
+      )}
       <div className='w-full flex justify-center items-center gap-5 flex-wrap'>
         {tags &&
           tags.map((tag: string, index: number) => (

--- a/apps/extension/src/screens/navigation-entries.screen.tsx
+++ b/apps/extension/src/screens/navigation-entries.screen.tsx
@@ -138,6 +138,7 @@ const NavigationEntry = ({
   useEffect(() => {
     setVisible(false);
   }, [element]);
+  //comment
   return (
     <div className='flex flex-col w-full bg-white px-2 py-1 rounded-lg mb-1 gap-3'>
       <div key={element.id} className='flex items-center justify-between'>

--- a/apps/extension/src/screens/navigation-entries.screen.tsx
+++ b/apps/extension/src/screens/navigation-entries.screen.tsx
@@ -138,7 +138,6 @@ const NavigationEntry = ({
   useEffect(() => {
     setVisible(false);
   }, [element]);
-  //comment
   return (
     <div className='flex flex-col w-full bg-white px-2 py-1 rounded-lg mb-1 gap-3'>
       <div key={element.id} className='flex items-center justify-between'>

--- a/apps/extension/src/screens/navigation-entries.screen.tsx
+++ b/apps/extension/src/screens/navigation-entries.screen.tsx
@@ -135,7 +135,9 @@ const NavigationEntry = ({
   deleteProps,
 }: NavEntryProps) => {
   const [visible, setVisible] = useState<boolean>(false);
-
+  useEffect(() => {
+    setVisible(false);
+  }, [element]);
   return (
     <div className='flex flex-col w-full bg-white px-2 py-1 rounded-lg mb-1 gap-3'>
       <div key={element.id} className='flex items-center justify-between'>


### PR DESCRIPTION
### Issue: #585 

### 📑 Changes:
- useEffect was added so when element changes, setVisible goes to false.
- Fixed tags found title when tags are not present
### ✅ Checks

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
