### PR TITLE
BUGFIX | WTM 589 | Fixed stoptracking preference not working

### DIFF
--- a/apps/backend/src/navigation/services/navigation-entry.service.ts
+++ b/apps/backend/src/navigation/services/navigation-entry.service.ts
@@ -174,9 +174,14 @@ export class NavigationEntryService {
           select: {
             enableImageEncoding: true,
             enableExplicitContentFilter: true,
+            enableStopTracking: true,
           },
         },
       );
+      if (userPreference?.enableStopTracking) {
+        return;
+      }
+
       if (userPreference?.enableExplicitContentFilter) {
         await this.explicitFilter.filter(
           content!,


### PR DESCRIPTION

### Issue: #589 

### 📑 Changes:
- When creating navigation entry, there was no validation if stopTracking was enabled or not.

### ✅ Checks

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
