### PR TITLE
Bugfix | WTM-666 | Use different loaders when the user submits login form

### DIFF
--- a/apps/webpage/src/app/login/page.tsx
+++ b/apps/webpage/src/app/login/page.tsx
@@ -176,7 +176,6 @@ const LoginScreen: React.FC<{}> = () => {
         <Button
           colorScheme='blue'
           variant={'outline'}
-          isLoading={loginMutation.isPending}
           className='w-full'
           onClick={() => navigateTo('sign-up')}
         >


### PR DESCRIPTION
### Issue: #666

### 📑 Changes:

- Loader from sign up button was removed

### ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
