### PR TITLE
Added logic for parsing

### DIFF
--- a/apps/backend/src/openai/service/open-ai.service.ts
+++ b/apps/backend/src/openai/service/open-ai.service.ts
@@ -43,10 +43,21 @@ export class OpenAIService {
     try {
       const formattedResult = await this.model.invoke([prompt]);
       const jsonParseFormattedResult = JSON.parse(formattedResult);
+      const finalJsonParsed = {
+        data: {
+          content:
+            jsonParseFormattedResult?.data?.content ||
+            jsonParseFormattedResult?.content,
+          tags:
+            jsonParseFormattedResult?.data?.tags ||
+            jsonParseFormattedResult?.tags,
+          source:
+            jsonParseFormattedResult?.data?.source ||
+            jsonParseFormattedResult?.source,
+        },
+      };
 
-      const parsedData = SummaryPromptSchema.safeParse(
-        jsonParseFormattedResult,
-      );
+      const parsedData = SummaryPromptSchema.safeParse(finalJsonParsed);
 
       if (!parsedData.success) {
         const error = `Failed to parse response: \n${parsedData.error.errors.map(


### PR DESCRIPTION
## HOTFIX

### 📑 Changes:

- Added logic for parsing
- The issue is that sometimes openai generates the object as it follows:
- `{data: {content: "MD Content"}, tags: [], source: "" }`
- So tags and source are out of data. With this fix we are involving this case on data, forcing it to be there, and afterwards, checking via Zod if it parses well.
### ✅ Checks

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
